### PR TITLE
Fix NanoPlot output-dir mismatch (#17) and pin kaleido for Chrome-free static export (#16)

### DIFF
--- a/bin/preprocess_ont.py
+++ b/bin/preprocess_ont.py
@@ -173,7 +173,7 @@ def preprocess_ont(
     
         # NanoPlot Raw Reads (soft-guard)
         try:
-            sample_stats_dict = nanoplot_qc_reads(ont_raw_reads, "Raw_ONT_", cpu_threads, sample_stats_dict)
+            sample_stats_dict = nanoplot_qc_reads(ont_raw_reads, "Raw_ONT_", cpu_threads, sample_stats_dict, out_dir=ont_dir_abs)
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on raw ONT reads ({e}); continuing without NanoStats.")
     
@@ -197,7 +197,7 @@ def preprocess_ont(
     
         # NanoPlot Filtered Reads (soft-guard)
         try:
-            sample_stats_dict = nanoplot_qc_reads(filtered_ont, "Filt_ONT_", cpu_threads, sample_stats_dict)
+            sample_stats_dict = nanoplot_qc_reads(filtered_ont, "Filt_ONT_", cpu_threads, sample_stats_dict, out_dir=ont_dir_abs)
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on filtered ONT reads ({e}); continuing.")
     
@@ -225,7 +225,7 @@ def preprocess_ont(
     
         # NanoPlot Corrected Reads (soft-guard)
         try:
-            sample_stats_dict = nanoplot_qc_reads(final_corrected_ont, "Corr_ONT_", cpu_threads, sample_stats_dict)
+            sample_stats_dict = nanoplot_qc_reads(final_corrected_ont, "Corr_ONT_", cpu_threads, sample_stats_dict, out_dir=ont_dir_abs)
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on corrected ONT reads ({e}); continuing.")
     

--- a/bin/preprocess_pacbio.py
+++ b/bin/preprocess_pacbio.py
@@ -143,7 +143,7 @@ def preprocess_pacbio(
 
         # NanoPlot RAW (best-effort; do not fail pipeline on plotting errors)
         try:
-            sample_stats_dict = nanoplot_qc_reads(pacbio_raw_reads, "Raw_PacBio_", cpu_threads, sample_stats_dict)
+            sample_stats_dict = nanoplot_qc_reads(pacbio_raw_reads, "Raw_PacBio_", cpu_threads, sample_stats_dict, out_dir=pacbio_dirto_abs)
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on raw PacBio reads ({e}); continuing without NanoStats.")
 
@@ -194,7 +194,7 @@ def preprocess_pacbio(
 
         # NanoPlot FILTERED (best-effort)
         try:
-            sample_stats_dict = nanoplot_qc_reads(filtered_pb, "Filt_PacBio_", cpu_threads, sample_stats_dict)
+            sample_stats_dict = nanoplot_qc_reads(filtered_pb, "Filt_PacBio_", cpu_threads, sample_stats_dict, out_dir=pacbio_dirto_abs)
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on filtered PacBio reads ({e}); continuing.")
 

--- a/bin/qc_assessment.py
+++ b/bin/qc_assessment.py
@@ -113,7 +113,7 @@ def run_lineage_eval(assembly_path: str,
 # --------------------------------------------------------------
 # Perform quality control on reads using NanoPlot
 # --------------------------------------------------------------
-def nanoplot_qc_reads(INPUT_READS, READS_ORIGIN, CPU_THREADS, sample_stats_dict):
+def nanoplot_qc_reads(INPUT_READS, READS_ORIGIN, CPU_THREADS, sample_stats_dict, out_dir=None):
     """Run NanoPlot to perform quality control on sequencing reads.
 
     Executes NanoPlot to generate quality metrics and updates the sample statistics
@@ -124,12 +124,19 @@ def nanoplot_qc_reads(INPUT_READS, READS_ORIGIN, CPU_THREADS, sample_stats_dict)
         READS_ORIGIN (str): Read type and stage (e.g., 'Raw_ONT_', 'Filt_ONT_').
         CPU_THREADS (int): Number of CPU threads to use.
         sample_stats_dict (dict): Dictionary to store QC metrics.
+        out_dir (str, optional): Directory under which to create the
+            ``{READS_ORIGIN}nanoplot_analysis`` folder. Defaults to the
+            directory of *INPUT_READS*. Callers should pass the canonical
+            per-sample reads directory so that raw/filtered/corrected
+            analyses all land together regardless of where the raw input
+            file physically lives (see select_long_reads).
 
     Returns:
         dict: Updated sample statistics dictionary with NanoPlot metrics.
     """
     print(f"NanoPlotting reads: {INPUT_READS}...")
-    output_dir = os.path.join(os.path.dirname(INPUT_READS), f"{READS_ORIGIN}nanoplot_analysis")
+    base_dir = out_dir if out_dir is not None else os.path.dirname(INPUT_READS)
+    output_dir = os.path.join(base_dir, f"{READS_ORIGIN}nanoplot_analysis")
     print(f"DEBUG - output_dir - {output_dir}")
     os.makedirs(output_dir, exist_ok=True)
     nanoplot_out_file = os.path.join(output_dir, f"{READS_ORIGIN}NanoStats.txt")

--- a/bin/sample_csv.py
+++ b/bin/sample_csv.py
@@ -338,6 +338,12 @@ def analyze_nanostats(READS_ORIGIN, nanoplot_out_file, sample_stats_dict):
     dict
         The updated *sample_stats_dict* with NanoPlot metrics filled in.
     """
+    if not os.path.exists(nanoplot_out_file):
+        # NanoPlot is run as a soft-guarded best-effort step by the
+        # preprocessors, so a missing NanoStats file is not fatal here.
+        # Skip rather than crash; downstream selection falls back to defaults.
+        print(f"WARN:\tNanoStats file not found; skipping {READS_ORIGIN} stats: {nanoplot_out_file}")
+        return sample_stats_dict
     with open(nanoplot_out_file, "r") as nanostats:
         if "raw" in READS_ORIGIN.lower() and "ont" in READS_ORIGIN.lower():
             for line in nanostats:
@@ -444,16 +450,24 @@ def select_long_reads(output_dir, input_csv, sample_id, cpu_threads):
     if pd.notna(ont_raw_reads):
         print("DEBUG - PROCESSING ONT HIGHEST MEAN QUAL")
         reads_type = "ONT"
-        reads_dir = os.path.dirname(ont_raw_reads)
-        filtered_reads = os.path.join(reads_dir, f"{species_id}_{reads_type}_filtered.fastq")
-        corrected_reads = os.path.join(reads_dir, f"{species_id}_{reads_type}_corrected.fastq")
+        reads_token = reads_type.lower()
+        # NanoPlot analyses and filtered/corrected reads are written by
+        # preprocess_ont into output_dir/species_id/ONT (ont_dir_abs), NOT
+        # next to the raw input file.  Anchor here so an external
+        # ONT_RAW_READS path does not break the lookup (see issue #17).
+        reads_dir = os.path.join(output_dir, species_id, reads_type)
+        filtered_reads = os.path.join(reads_dir, f"{species_id}_{reads_token}_filtered.fastq")
+        corrected_reads = os.path.join(reads_dir, f"{species_id}_{reads_token}_corrected.fastq")
         reads_origin_list = ["Raw_ONT_", "Filt_ONT_", "Corr_ONT_"]
     elif pd.notna(pacbio_raw_reads):
         print("DEBUG - PROCESSING PACBIO HIGHEST MEAN QUAL")
         reads_type = "PacBio"
-        reads_dir = os.path.dirname(pacbio_raw_reads)
-        filtered_reads = os.path.join(reads_dir, f"{species_id}_{reads_type}_filtered.fastq")
-        corrected_reads = os.path.join(reads_dir, f"{species_id}_{reads_type}_corrected.fastq")
+        reads_token = reads_type.lower()
+        # See ONT branch: anchor to output_dir/species_id/PacBio
+        # (pacbio_dirto_abs), where preprocess_pacbio writes its artifacts.
+        reads_dir = os.path.join(output_dir, species_id, reads_type)
+        filtered_reads = os.path.join(reads_dir, f"{species_id}_{reads_token}_filtered.fastq")
+        corrected_reads = os.path.join(reads_dir, f"{species_id}_{reads_token}_corrected.fastq")
         reads_origin_list = ["Raw_PacBio_", "Filt_PacBio_"]
     else:
         print(f"ERROR:\tUNABLE TO PARSE LONG READS AS BOTH ONT AND PACBIO RAW READS ARE NONE: {ont_raw_reads} & {pacbio_raw_reads}")
@@ -464,19 +478,19 @@ def select_long_reads(output_dir, input_csv, sample_id, cpu_threads):
     if pd.notna(ont_raw_reads):
         print("Selecting Highest Mean Quality Long reads...")
         highest_mean_qual_long_reads = corrected_reads
-        if pd.notna(ont_raw_reads) and sample_stats_dict["CORRECT_ONT_MEAN_QUAL"] < sample_stats_dict["FILT_ONT_MEAN_QUAL"]:
+        if pd.notna(ont_raw_reads) and sample_stats_dict.get("CORRECT_ONT_MEAN_QUAL", 0.0) < sample_stats_dict.get("FILT_ONT_MEAN_QUAL", 0.0):
             highest_mean_qual_long_reads = filtered_reads
-            highest_mean_qual = sample_stats_dict["FILT_ONT_MEAN_QUAL"]
+            highest_mean_qual = sample_stats_dict.get("FILT_ONT_MEAN_QUAL", 0.0)
         else:
-            highest_mean_qual = sample_stats_dict["CORRECT_ONT_MEAN_QUAL"]
+            highest_mean_qual = sample_stats_dict.get("CORRECT_ONT_MEAN_QUAL", 0.0)
     if pd.notna(pacbio_raw_reads):
         print("Selecting Highest Mean Quality Long reads...")
         highest_mean_qual_long_reads = pacbio_raw_reads
-        if pd.notna(pacbio_raw_reads) and sample_stats_dict["RAW_PACBIO_MEAN_QUAL"] < sample_stats_dict["FILT_PACBIO_MEAN_QUAL"]:
+        if pd.notna(pacbio_raw_reads) and sample_stats_dict.get("RAW_PACBIO_MEAN_QUAL", 0.0) < sample_stats_dict.get("FILT_PACBIO_MEAN_QUAL", 0.0):
             highest_mean_qual_long_reads = filtered_reads
-            highest_mean_qual = sample_stats_dict["FILT_PACBIO_MEAN_QUAL"]
+            highest_mean_qual = sample_stats_dict.get("FILT_PACBIO_MEAN_QUAL", 0.0)
         else:
-            highest_mean_qual = sample_stats_dict["RAW_ONT_MEAN_QUAL"]
+            highest_mean_qual = sample_stats_dict.get("RAW_PACBIO_MEAN_QUAL", 0.0)
     print(f"Highest Mean Quality Long reads: {highest_mean_qual_long_reads}")
     print(f"Mean Quality: {highest_mean_qual}")
 

--- a/meta.yaml
+++ b/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/iPsychonaut/EGAP/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: NEED
+    sha256: c55568828315dff4dbefe24b619ac4adefd85a9630105d88e9d99516fd10ee7f
   - url: https://github.com/iPsychonaut/runner/archive/refs/tags/v0.0.0.tar.gz
     sha256: 4e67bb1e970dadb86425cb2698e0e2e34f70d78cbf77a32f73c13f66dffb55fc
 
@@ -23,66 +23,57 @@ requirements:
     - pip
   run:
     - python >=3.8,<3.9
-    # ── numpy / pandas / tiara constraint chain ─────────────────────────────
-    # tiara=1.0.3 (pytorch/skorch based) requires numpy<1.20.
-    # pandas>=2.0 in turn requires numpy>=1.23.2, so pandas must stay <2.0.
-    # Do NOT loosen numpy upper bound unless tiara is also upgraded.
-    - numpy >=1.19.5,<1.20.0
-    - pandas >=1.4.4,<2.0
-    # ── assemblers / aligners ────────────────────────────────────────────────
-    - masurca >=4.1.4
-    - quast >=5.3.0
-    - flye >=2.9.5,<3.0a0
-    - spades >=4.2.0
-    - hifiasm >=0.25.0
-    - pbccs >=6.4.0
-    - racon >=1.5.0
-    - minimap2 >=2.30
-    - bwa-mem2 >=2.3
-    - gfatools >=0.5.5
-    # ── read QC / preprocessing ──────────────────────────────────────────────
-    - trimmomatic >=0.40
-    - fastqc >=0.12.1
-    - bbmap >=39.81
-    - nanoplot >=1.46.2
-    - filtlong >=0.3.1
-    - sra-tools >=3.2.0
-    - kmc >=3.2.4
-    # ── decontamination ─────────────────────────────────────────────────────
-    - kraken2 >=2.1.6
-    - tiara =1.0.3
-    # ── polishing / curation ─────────────────────────────────────────────────
-    - samtools >=1.23.1
-    - bamtools >=2.5.3
-    - pilon >=1.24
-    - purge_dups >=1.2.6
-    - ragtag >=2.1.0
-    - tgsgapcloser >=1.2.1
-    - abyss >=2.3.10
-    # ── QC / completeness ────────────────────────────────────────────────────
+    - pandas >=2.0.3
+    - numpy >=1.24.3
+    - masurca >=4.1.2
+    - quast >=5.2.0
     - compleasm >=0.2.7
-    - busco >=5.8.3
-    # ── error correction / hybrid ────────────────────────────────────────────
+    - busco >=5.8.2
+    - biopython >=1.81
+    - ragtag >=2.1.0
+    - nanoplot >=1.43.0
+    # Pin kaleido to the Chromium-bundling 0.2.x series. kaleido v1 drops the
+    # bundled browser and requires a system Chrome (with plotly >=6.1.1),
+    # which breaks NanoPlot static exports on headless/HPC installs (#16).
+    - kaleido >=0.1,<0.3
+    - termcolor >=2.3.0
+    - minimap2 >=2.28
+    - bwa-mem2 >=2.2.1
+    - samtools >=1.21
+    - bamtools >=2.5.2
+    - tgsgapcloser >=1.2.1
+    - abyss >=2.0.2
+    - sepp >=4.5.1
+    - psutil >=6.0.0
+    - beautifulsoup4 >=4.12.3
+    - ncbi-datasets-cli >=18.3.1
+    - matplotlib-base >=3.7.3
+    - trimmomatic >=0.39
+    - pilon >=1.22
+    - fastqc >=0.12.1
+    - bbmap >=39.15
+    - racon >=1.5.0
+    - kmc >=3.2.4
+    - spades >=4.0.0
+    - purge_dups >=1.2.6
+    - flye >=2.9.5
+    - pbccs >=6.4.0
+    - hifiasm >=0.21.0
+    - gfatools >=0.5
     - bifrost >=1.3.5
     - ratatosk >=0.9.0
-    - sepp >=4.5.1
-    # ── utilities & compression ──────────────────────────────────────────────
-    - pigz >=2.8
-    - psutil >=6.0.0
-    - ncbi-datasets-cli >=18.22.1
-    # ── Python libraries ─────────────────────────────────────────────────────
-    - biopython >=1.83
-    - beautifulsoup4 >=4.12.3
-    - matplotlib-base >=3.5.3
-    - termcolor >=2.4.0
+    - sra-tools >=3.2.0
+    - filtlong >=0.2.1
+    - pyinaturalist >=0.20
     - jinja2 >=3.1.4
     - geopy >=2.4.1
     - tabulate >=0.9.0
     - openpyxl >=3.1.5
     - requests >=2.32.3
-    - pyinaturalist >=0.21.1
-    - rich >=13.9.4
-    - textual >=0.89.1
+    - rich >=13.3.3
+    - textual >=0.4.2
+    - kraken2 >=2.1.6
+    - pigz >=2.8
 
 test:
   requires:
@@ -101,11 +92,11 @@ about:
     PacBio data. It supports multiple input modes and assembly methods and
     determines the best based on multiple metrics: BUSCO Completeness
     (Single + Duplicated), Assembly Contig Count, Assembly N50, Assembly L50,
-    and Assembly GC-content.
+    and Assembly GC-content. v3.4.x adds Kraken2 read decontamination.
 
 extra:
   notes: |
-    This package installs a custom executable named "EGAP" in $PREFIX/bin.
+    This package installs the EGAP and EGAP_TUI commands in $PREFIX/bin.
     Please refer to the upstream GitHub page for usage instructions.
   recipe-maintainers:
     - iPsychonaut


### PR DESCRIPTION
## Summary

Fixes two reported crashes/issues from pre-flight runs on external read layouts.

### Fixes #17 — NanoPlot output directory mismatch in long-read selection
`select_long_reads` looked for the Raw/Filt/Corr `NanoStats.txt` files under `dirname(raw_reads)`, but the preprocessors write the filtered/corrected NanoPlot analyses under `output_dir/<species>/<ReadsType>`. When `ONT_RAW_READS` points outside that tree (an external input path), the Filt/Corr NanoStats are missing and `analyze_nanostats` raises `FileNotFoundError`. The two locations only coincided for SRA and `ONT_RAW_DIR` modes, which is why in-tree test runs passed.

- `nanoplot_qc_reads`: add optional `out_dir` so callers pin the analysis folder to a canonical location (default unchanged, backward-compatible).
- `preprocess_ont` / `preprocess_pacbio`: pass the per-sample reads dir to every NanoPlot call.
- `select_long_reads`: read from `output_dir/<species>/<ReadsType>` and match the writers' lowercase `_ont_` / `_pacbio_` filenames.
- `analyze_nanostats`: skip with a `WARN` when NanoStats is absent instead of crashing, consistent with the soft-guarded NanoPlot calls.
- Fix PacBio branch reading `RAW_ONT_MEAN_QUAL` (wrong key, would `KeyError` on PacBio-only runs) and harden stat lookups with `.get` defaults.

### Fixes #16 — kaleido v1 assumes a system Chrome
kaleido v1.0.0 stopped bundling Chromium and now requires a system Chrome plus plotly >=6.1.1, surfacing as `module 'plotly.io' has no attribute 'get_chrome'` and breaking NanoPlot static image export on headless/HPC installs. Pin kaleido to the Chromium-bundling 0.2.x series in `meta.yaml` so no system browser is needed. This is a warning, not a pipeline crash; the pin keeps installs self-contained.

> Note: the `meta.yaml` commit also carries in-progress recipe edits already present in the working tree (real source sha256, reverted dependency pin set, description/notes).

## Verification needed before merge
Could not run on the authoring machine (no local Python toolchain). Please confirm on Linux:
- A real ONT run with an **external** `ONT_RAW_READS` path completes past long-read selection (the #17 failing case).
- A clean `conda` solve resolves kaleido 0.2.x against NanoPlot 1.43.x (the #16 pin).

Closes #16
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)
