### PR TITLE
Input source priority (files > dir > SRA) and case-insensitive QUAST organism flags

### DIFF
--- a/bin/preprocess_illumina.py
+++ b/bin/preprocess_illumina.py
@@ -412,8 +412,36 @@ def preprocess_illumina(sample_id, input_csv, output_dir, cpu_threads, ram_gb):
     illumina_dir = species_dir / "Illumina"
     illumina_dir.mkdir(parents=True, exist_ok=True)
 
-    # ---- CASE A: SRA accession provided; ensure R1/R2 exist or download ----
-    if pd.notna(illu_sra) and pd.isna(illu_raw_f_reads) and pd.isna(illu_raw_r_reads):
+    # Resolve the Illumina input source in priority order:
+    #   1) explicit ILLUMINA_RAW_F_READS + _R_READS, if both are real and non-empty
+    #   2) else combine/verify a raw directory (ILLUMINA_RAW_DIR)
+    #   3) else download ILLUMINA_SRA
+    # Use the first source that resolves; fall through to the next otherwise.
+    resolved_f, resolved_r = None, None
+
+    # 1) Explicit paired files
+    if illu_raw_f_reads is not None and illu_raw_r_reads is not None:
+        f_cand = str(illu_raw_f_reads).strip()
+        r_cand = str(illu_raw_r_reads).strip()
+        if nonempty(f_cand) and nonempty(r_cand):
+            resolved_f, resolved_r = f_cand, r_cand
+            log_print(f"NOTE:\tUsing provided Illumina paired reads: {resolved_f}, {resolved_r}")
+        else:
+            log_print(f"WARN:\tILLUMINA_RAW_F/R_READS provided but not both found/non-empty "
+                      f"(R1={f_cand}, R2={r_cand}); trying directory, then SRA.")
+
+    # 2) Raw directory; combine/verify there
+    if (resolved_f is None or resolved_r is None) and illu_raw_dir is not None:
+        log_print(f"Process Illumina Raw Directory: {illu_raw_dir}...")
+        combined_list = illumina_extract_and_check(str(illu_raw_dir), sample_id)
+        if combined_list:
+            resolved_f, resolved_r = combined_list[0], combined_list[1]
+            log_print("PASS:\tSuccessfully processed Illumina Raw Directory.")
+        else:
+            log_print(f"WARN:\tFailed to process Illumina Raw Directory for {sample_id}; trying SRA.")
+
+    # 3) SRA accession; download R1/R2 if not already present
+    if (resolved_f is None or resolved_r is None) and illu_sra is not None:
         sra_id = str(illu_sra).strip()
         r1 = illumina_dir / f"{sra_id}_1.fastq"
         r2 = illumina_dir / f"{sra_id}_2.fastq"
@@ -465,28 +493,13 @@ def preprocess_illumina(sample_id, input_csv, output_dir, cpu_threads, ram_gb):
 
             log_print(f"PASS:\tIllumina SRA processed: {r1}, {r2}")
 
-        illu_raw_f_reads = str(r1)
-        illu_raw_r_reads = str(r2)
+        resolved_f, resolved_r = str(r1), str(r2)
 
-    # ---- CASE B: Raw directory provided; combine/verify there ----
-    elif pd.notna(illu_raw_dir) and (pd.isna(illu_raw_f_reads) or pd.isna(illu_raw_r_reads)):
-        log_print(f"Process Illumina Raw Directory: {illu_raw_dir}...")
-        combined_list = illumina_extract_and_check(str(illu_raw_dir), sample_id)
-        if combined_list:
-            log_print("PASS:\tSuccessfully processed Illumina Raw Directory.")
-            illu_raw_f_reads, illu_raw_r_reads = combined_list[0], combined_list[1]
-            # Update the 'SRA' field logically for downstream logging (won't rewrite CSV here)
-        else:
-            log_print(f"ERROR:\tFailed to process Illumina Raw Directory for {sample_id}")
-            return None, None
+    if resolved_f is None or resolved_r is None:
+        log_print("SKIP:\tIllumina preprocessing; no usable paired reads resolved from files, directory, or SRA")
+        return None, None
 
-    # If both explicit files provided in CSV, just trust them
-    else:
-        # Normalize strings if they exist
-        if pd.notna(illu_raw_f_reads):
-            illu_raw_f_reads = str(illu_raw_f_reads).strip()
-        if pd.notna(illu_raw_r_reads):
-            illu_raw_r_reads = str(illu_raw_r_reads).strip()
+    illu_raw_f_reads, illu_raw_r_reads = resolved_f, resolved_r
 
     # Final guard: we must have both R1 and R2 paths now
     if not illu_raw_f_reads or not illu_raw_r_reads or not os.path.exists(illu_raw_f_reads) or not os.path.exists(illu_raw_r_reads):

--- a/bin/preprocess_ont.py
+++ b/bin/preprocess_ont.py
@@ -97,14 +97,8 @@ def preprocess_ont(
     ont_dir_abs = os.path.join(species_dir_abs, "ONT")
     os.makedirs(ont_dir_abs, exist_ok=True)
 
-    # Normalize ONT inputs BEFORE any chdir
-    if ont_sra is not None and ont_raw_reads is None:
-        # Expected dump location for SRA
-        ont_raw_reads = os.path.join(ont_dir_abs, f"{ont_sra}.fastq")
-    elif isinstance(ont_raw_reads, str) and not os.path.isabs(ont_raw_reads):
-        # If given a relative path, make it absolute relative to ctx.output_dir (project root),
-        # not the current cwd (prevents nested repetition)
-        ont_raw_reads = os.path.abspath(os.path.join(ctx.output_dir, ont_raw_reads))
+    # Input source is resolved in priority order (file > directory > SRA)
+    # after the chdir below.
 
     # Illumina dedup (absolute paths so downstream tools can find them regardless of cwd)
     illu_dedup_f_reads = os.path.join(species_dir_abs, "Illumina", f"{species_id}_illu_forward_dedup.fastq")
@@ -125,37 +119,56 @@ def preprocess_ont(
     os.chdir(ont_dir_abs)
     
     try:
-        # Handle Raw Data Directory (concatenate .fastq files)
-        if ont_raw_dir is not None:
-            print(f"NOTE:\tConcatenating ONT files from {ont_raw_dir}")
+        # Resolve the ONT input source in priority order:
+        #   1) explicit ONT_RAW_READS file, if it is real and non-empty
+        #   2) else concatenate a directory of *.fastq (ONT_RAW_DIR)
+        #   3) else download ONT_SRA
+        # Use the first source that resolves; fall through to the next otherwise.
+        resolved_reads = None
+
+        # 1) Explicit file
+        if ont_raw_reads is not None:
+            candidate = ont_raw_reads if os.path.isabs(ont_raw_reads) \
+                else os.path.abspath(os.path.join(ctx.output_dir, ont_raw_reads))
+            if os.path.exists(candidate) and os.path.getsize(candidate) > 0:
+                resolved_reads = candidate
+                print(f"NOTE:\tUsing provided ONT reads file: {resolved_reads}")
+            else:
+                print(f"WARN:\tONT_RAW_READS provided but not found/empty ({candidate}); trying directory, then SRA.")
+
+        # 2) Directory of fastqs to concatenate
+        if resolved_reads is None and ont_raw_dir is not None:
             ont_raw_dir_abs = ont_raw_dir if os.path.isabs(ont_raw_dir) else os.path.join(ctx.output_dir, ont_raw_dir)
             ont_files = sorted(glob.glob(os.path.join(ont_raw_dir_abs, "*.fastq")))
-            if not ont_files:
-                print(f"ERROR:\tNo ONT files found in {ont_raw_dir_abs}")
-                sys.exit(1)
-            ont_raw_reads = os.path.join(ont_dir_abs, f"{species_id}_ont_combined.fastq")
-            with open(ont_raw_reads, "wb") as w:
-                for f in ont_files:
-                    with open(f, "rb") as r:
-                        shutil.copyfileobj(r, w)
-    
-        # SRA download to the ONT directory (no relative -O that repeats the path)
-        if ont_sra is not None:
-            if not ont_raw_reads or not os.path.exists(ont_raw_reads):
+            if ont_files:
+                print(f"NOTE:\tConcatenating {len(ont_files)} ONT file(s) from {ont_raw_dir_abs}")
+                combined = os.path.join(ont_dir_abs, f"{species_id}_ont_combined.fastq")
+                with open(combined, "wb") as w:
+                    for f in ont_files:
+                        with open(f, "rb") as r:
+                            shutil.copyfileobj(r, w)
+                resolved_reads = combined
+            else:
+                print(f"WARN:\tONT_RAW_DIR provided but no .fastq files in {ont_raw_dir_abs}; trying SRA.")
+
+        # 3) SRA download
+        if resolved_reads is None and ont_sra is not None:
+            dumped = os.path.join(ont_dir_abs, f"{ont_sra}.fastq")
+            if not os.path.exists(dumped) or os.path.getsize(dumped) == 0:
                 print(f"Downloading SRA {ont_sra} from GenBank...")
                 _ = run_subprocess_cmd(["prefetch", "--force", "yes", ont_sra], False)
                 _ = run_subprocess_cmd(["fasterq-dump", "-e", str(cpu_threads), "-O", ont_dir_abs, ont_sra], False)
-                dumped = os.path.join(ont_dir_abs, f"{ont_sra}.fastq")
-                if not os.path.exists(dumped):
-                    print("ERROR:\tExpected FASTQ not found after fasterq-dump.")
-                    return None
-                if os.path.getsize(dumped) == 0:
-                    print(f"ERROR:\tDownloaded FASTQ is empty: {dumped}")
-                    return None
-                ont_raw_reads = dumped
-                print(f"PASS:\tSRA converted to FASTQ: {ont_raw_reads}")
-            else:
-                print(f"SKIP:\tSRA already exists: {ont_raw_reads}")
+            if not os.path.exists(dumped) or os.path.getsize(dumped) == 0:
+                print(f"ERROR:\tExpected FASTQ not found or empty after fasterq-dump: {dumped}")
+                return None
+            resolved_reads = dumped
+            print(f"PASS:\tSRA converted to FASTQ: {resolved_reads}")
+
+        if resolved_reads is None:
+            print("SKIP:\tONT preprocessing; no usable reads resolved from file, directory, or SRA")
+            return None
+
+        ont_raw_reads = resolved_reads
     
         # Parse estimated genome size
         m = re.match(r"^(\d+(?:\.\d+)?)(\D+)$", str(est_size))
@@ -177,10 +190,9 @@ def preprocess_ont(
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on raw ONT reads ({e}); continuing without NanoStats.")
     
-        # Filtlong (only include Illumina if those files actually exist)
-        filtered_ont = os.path.join(ont_dir_abs,
-                                    f"{species_id}_ont_filtered.fastq" if not isinstance(ont_sra, str)
-                                    else os.path.basename(ont_raw_reads).replace(f"{ont_sra}", f"{species_id}_ont_filtered"))
+        # Filtlong (only include Illumina if those files actually exist).
+        # Canonical filtered name regardless of which input source resolved.
+        filtered_ont = os.path.join(ont_dir_abs, f"{species_id}_ont_filtered.fastq")
         coverage = 75
         target_bases = est_size_bp * coverage
         use_illumina = os.path.exists(illu_dedup_f_reads) and os.path.exists(illu_dedup_r_reads)

--- a/bin/preprocess_pacbio.py
+++ b/bin/preprocess_pacbio.py
@@ -82,11 +82,8 @@ def preprocess_pacbio(
     pacbio_dirto_abs  = os.path.join(species_dirto_abs, "PacBio")
     os.makedirs(pacbio_dirto_abs, exist_ok=True)
 
-    # Normalize implied paths BEFORE any chdir
-    if pd.notna(pacbio_sra) and pd.isna(pacbio_raw_reads):
-        pacbio_raw_reads = os.path.join(pacbio_dirto_abs, f"{pacbio_sra}.fastq")
-    elif isinstance(pacbio_raw_reads, str) and not os.path.isabs(pacbio_raw_reads):
-        pacbio_raw_reads = to_abs(os.path.join(ctx.output_dir, pacbio_raw_reads))
+    # PacBio input source is resolved in priority order (file > directory > SRA)
+    # inside the try block below; no pre-chdir path munging needed here.
 
     # Normalize reference FASTA if only GCA is present
     if pd.notna(ref_seq_gca) and (pd.isna(ref_seq) or not isinstance(ref_seq, str) or not ref_seq.strip()):
@@ -97,34 +94,55 @@ def preprocess_pacbio(
     prev_cwd = os.getcwd()
     os.chdir(pacbio_dirto_abs)
     try:
-        # Option 1: concatenate raw dir *.fastq
-        if isinstance(pacbio_raw_dir, str) and pacbio_raw_dir.strip():
+        # Resolve the PacBio input source in priority order:
+        #   1) explicit PACBIO_RAW_READS file, if it is real and non-empty
+        #   2) else concatenate a directory of *.fastq (PACBIO_RAW_DIR)
+        #   3) else download PACBIO_SRA
+        # Use the first source that resolves; fall through to the next otherwise.
+        resolved_reads = None
+
+        # 1) Explicit file
+        if isinstance(pacbio_raw_reads, str) and pacbio_raw_reads.strip():
+            candidate = pacbio_raw_reads if os.path.isabs(pacbio_raw_reads) else to_abs(os.path.join(ctx.output_dir, pacbio_raw_reads))
+            if os.path.exists(candidate) and os.path.getsize(candidate) > 0:
+                resolved_reads = candidate
+                print(f"NOTE:\tUsing provided PacBio reads file: {resolved_reads}")
+            else:
+                print(f"WARN:\tPACBIO_RAW_READS provided but not found/empty ({candidate}); trying directory, then SRA.")
+
+        # 2) Directory of fastqs to concatenate
+        if resolved_reads is None and isinstance(pacbio_raw_dir, str) and pacbio_raw_dir.strip():
             pb_raw_dirto_abs = pacbio_raw_dir if os.path.isabs(pacbio_raw_dir) else os.path.join(ctx.output_dir, pacbio_raw_dir)
             files = sorted(glob.glob(os.path.join(pb_raw_dirto_abs, "*.fastq")))
-            if not files:
-                print(f"ERROR:\tNo PacBio .fastq files found in {pb_raw_dirto_abs}")
-                return None
-            pacbio_raw_reads = os.path.join(pacbio_dirto_abs, f"{species_id}_pacbio_combined.fastq")
-            print(f"NOTE:\tConcatenating PacBio files from {pb_raw_dirto_abs} -> {pacbio_raw_reads}")
-            with open(pacbio_raw_reads, "wb") as w:
-                for f in files:
-                    with open(f, "rb") as r:
-                        shutil.copyfileobj(r, w)
+            if files:
+                combined = os.path.join(pacbio_dirto_abs, f"{species_id}_pacbio_combined.fastq")
+                print(f"NOTE:\tConcatenating {len(files)} PacBio file(s) from {pb_raw_dirto_abs} -> {combined}")
+                with open(combined, "wb") as w:
+                    for f in files:
+                        with open(f, "rb") as r:
+                            shutil.copyfileobj(r, w)
+                resolved_reads = combined
+            else:
+                print(f"WARN:\tPACBIO_RAW_DIR provided but no .fastq files in {pb_raw_dirto_abs}; trying SRA.")
 
-        # Option 2: SRA -> FASTQ into PacBio dir (ensure -O is used)
-        if isinstance(pacbio_sra, str) and pacbio_sra.strip():
-            if not pacbio_raw_reads or not os.path.exists(pacbio_raw_reads):
+        # 3) SRA download
+        if resolved_reads is None and isinstance(pacbio_sra, str) and pacbio_sra.strip():
+            expected = os.path.join(pacbio_dirto_abs, f"{pacbio_sra}.fastq")
+            if not os.path.exists(expected) or os.path.getsize(expected) == 0:
                 print(f"Downloading SRA {pacbio_sra} from GenBank...")
                 _ = run_subprocess_cmd(["prefetch", "--force", "yes", pacbio_sra], False)
                 _ = run_subprocess_cmd(["fasterq-dump", "--threads", str(cpu_threads), "-O", pacbio_dirto_abs, pacbio_sra], False)
-                expected = os.path.join(pacbio_dirto_abs, f"{pacbio_sra}.fastq")
-                if not os.path.exists(expected) or os.path.getsize(expected) == 0:
-                    print(f"ERROR:\tExpected FASTQ not found or empty after fasterq-dump: {expected}")
-                    return None
-                pacbio_raw_reads = expected
-                print(f"PASS:\tSRA converted to FASTQ: {pacbio_raw_reads}")
-            else:
-                print(f"SKIP:\tSRA already present as FASTQ: {pacbio_raw_reads}")
+            if not os.path.exists(expected) or os.path.getsize(expected) == 0:
+                print(f"ERROR:\tExpected FASTQ not found or empty after fasterq-dump: {expected}")
+                return None
+            resolved_reads = expected
+            print(f"PASS:\tSRA converted to FASTQ: {resolved_reads}")
+
+        if resolved_reads is None:
+            print("SKIP:\tPacBio preprocessing; no usable reads resolved from file, directory, or SRA")
+            return None
+
+        pacbio_raw_reads = resolved_reads
 
         # Validate raw reads
         if not pacbio_raw_reads or not os.path.exists(pacbio_raw_reads) or os.path.getsize(pacbio_raw_reads) == 0:
@@ -147,11 +165,8 @@ def preprocess_pacbio(
         except Exception as e:
             print(f"WARN:\tNanoPlot failed on raw PacBio reads ({e}); continuing without NanoStats.")
 
-        # Decide filtered output path
-        if isinstance(pacbio_sra, str) and pacbio_sra.strip():
-            filtered_pb = os.path.join(pacbio_dirto_abs, os.path.basename(pacbio_raw_reads).replace(pacbio_sra, f"{species_id}_pacbio_filtered"))
-        else:
-            filtered_pb = os.path.join(pacbio_dirto_abs, f"{species_id}_pacbio_filtered.fastq")
+        # Canonical filtered name regardless of which input source resolved.
+        filtered_pb = os.path.join(pacbio_dirto_abs, f"{species_id}_pacbio_filtered.fastq")
 
         # If an old filtered file exists but is empty/suspicious, remove it to force regeneration
         if os.path.exists(filtered_pb) and not nonempty(filtered_pb):

--- a/bin/qc_assessment.py
+++ b/bin/qc_assessment.py
@@ -680,7 +680,7 @@ def qc_assessment(assembly_type, input_csv, sample_id, output_dir, cpu_threads, 
         # ``if`` -- so we explicitly check for non-null before comparing.
         if pd.notna(karyote_id) and str(karyote_id).strip().lower() == "eukaryote":
             quast_cmd.append("--eukaryote")
-        if pd.notna(kingdom_id) and kingdom_id == "Funga":
+        if pd.notna(kingdom_id) and str(kingdom_id).strip().lower() == "funga":
             quast_cmd.append("--fungus")
         if pd.notna(ref_seq) and os.path.exists(ref_seq):
             quast_cmd.extend(["-r", ref_seq])
@@ -985,7 +985,7 @@ def final_assessment(assembly_type, input_csv, sample_id, output_dir, cpu_thread
         # ``if`` -- so we explicitly check for non-null before comparing.
         if pd.notna(karyote_id) and str(karyote_id).strip().lower() == "eukaryote":
             quast_cmd.append("--eukaryote")
-        if pd.notna(kingdom_id) and kingdom_id == "Funga":
+        if pd.notna(kingdom_id) and str(kingdom_id).strip().lower() == "funga":
             quast_cmd.append("--fungus")
         if pd.notna(ref_seq) and os.path.exists(ref_seq):
             quast_cmd.extend(["-r", ref_seq])

--- a/bin/qc_assessment.py
+++ b/bin/qc_assessment.py
@@ -678,7 +678,7 @@ def qc_assessment(assembly_type, input_csv, sample_id, output_dir, cpu_threads, 
         # ``pd.NA == "eukaryote"`` returns ``pd.NA``, which raises
         # ``TypeError: boolean value of NA is ambiguous`` when used in an
         # ``if`` -- so we explicitly check for non-null before comparing.
-        if pd.notna(karyote_id) and karyote_id == "eukaryote":
+        if pd.notna(karyote_id) and str(karyote_id).strip().lower() == "eukaryote":
             quast_cmd.append("--eukaryote")
         if pd.notna(kingdom_id) and kingdom_id == "Funga":
             quast_cmd.append("--fungus")
@@ -983,7 +983,7 @@ def final_assessment(assembly_type, input_csv, sample_id, output_dir, cpu_thread
         # ``pd.NA == "eukaryote"`` returns ``pd.NA``, which raises
         # ``TypeError: boolean value of NA is ambiguous`` when used in an
         # ``if`` -- so we explicitly check for non-null before comparing.
-        if pd.notna(karyote_id) and karyote_id == "eukaryote":
+        if pd.notna(karyote_id) and str(karyote_id).strip().lower() == "eukaryote":
             quast_cmd.append("--eukaryote")
         if pd.notna(kingdom_id) and kingdom_id == "Funga":
             quast_cmd.append("--fungus")


### PR DESCRIPTION
## Summary

Makes read-input resolution deterministic across the three preprocessors and makes the QUAST organism flags tolerant of CSV capitalization.

### Input source priority: Files → Directory → SRA
When more than one input source is provided for a modality, resolve in one explicit order and use the first that actually resolves, falling through otherwise:

1. explicit `*_RAW_READS` file(s) — used only if real and non-empty (Illumina requires **both** F and R)
2. else concatenate a `*_RAW_DIR` of `*.fastq`
3. else download the `*_SRA` accession

Previously the directory/SRA branches could run even when valid explicit files were given. With both a `RAW_DIR` and a `RAW_READS` file pointing at the same folder (and the combined file living inside that folder), the directory glob re-concatenated the merged file together with its own sources, double-counting reads. Preferring the explicit file avoids that. Invalid higher-priority sources now log a `WARN` and fall through instead of hard-exiting.

- `preprocess_ont.py` / `preprocess_pacbio.py`: single file > dir > SRA resolver replacing the scattered normalize + dir + SRA blocks.
- `preprocess_illumina.py`: same order for paired F/R reads.
- Dropped the SRA-derived filtered-filename special case in ont/pacbio; always use the canonical `{species}_{ont,pacbio}_filtered.fastq`, which is what `select_long_reads` expects.

### Case-insensitive ORGANISM_KARYOTE / ORGANISM_KINGDOM for QUAST flags
A capitalized `Eukaryote` / `Funga` in the CSV previously failed the exact-match checks and silently dropped QUAST's `--eukaryote` / `--fungus` flags. Both checks now normalize with `str(...).strip().lower()` in both QUAST blocks. (There is no `--prokaryote` flag; prokaryote is QUAST's default, so capitalized `Prokaryote` already behaves correctly.)

## Verification needed before relying on output
Could not byte-compile or run on the authoring machine (no local Python). Please confirm on Linux:
- A multi-sample run where a row sets both `ONT_RAW_DIR` and `ONT_RAW_READS` uses the explicit file and does not double-count.
- QUAST receives `--eukaryote` / `--fungus` for a fungal sample regardless of CSV casing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
